### PR TITLE
Support '--<option>=<value>' form for long options

### DIFF
--- a/src/ArgumentParser.cs
+++ b/src/ArgumentParser.cs
@@ -73,6 +73,22 @@ namespace De.Thekid.INotify
 			{
 				result.Exclude = new Regex(Value(args, ++i, "exclude"), RegexOptions.IgnoreCase);
 			}
+			else if (option.StartsWith("--event="))
+			{
+				result.Events = new List<string>(option.Split(new Char[]{'='}, 2)[1].Split(','));
+			}
+			else if (option.StartsWith("--format="))
+			{
+				result.Format = TokenizeFormat(option.Split(new Char[]{'='}, 2)[1]);
+			}
+			else if (option.StartsWith("--exclude="))
+			{
+				result.Exclude = new Regex(option.Split(new Char[]{'='}, 2)[1]);
+			}
+			else if (option.StartsWith("--excludei="))
+			{
+				result.Exclude = new Regex(option.Split(new Char[]{'='}, 2)[1], RegexOptions.IgnoreCase);
+			}
 			else if (Directory.Exists(option))
 			{
 				result.Paths.Add(System.IO.Path.GetFullPath(option));


### PR DESCRIPTION
The Linux version of inotifywait uses getopts to parse the commandline
arguments. This supports long options in two formats: the regular
"argument" '`--<option> <value>`' form, and the "equals" '`--<option>=<value>`'
form.

To improve portability of scripts that might use the "equals" form, add
support for this to the argument parser.

Usage of getopts in inotifywait: https://github.com/rvoicilas/inotify-tools/blob/master/src/inotifywait.c#L560
Man page of getopts which also describes the '`--<option>=<value>`' form: http://linux.die.net/man/3/getopt
