### PR TITLE
Stop monitoring when stdin shuts down

### DIFF
--- a/src/Runner.cs
+++ b/src/Runner.cs
@@ -110,6 +110,12 @@ namespace De.Thekid.INotify
 			writer.WriteLine();
 		}
 
+		public void Stop(object data) {
+			while(Console.ReadLine() != null){ };
+			_stopMonitoring = true;
+			_stopMonitoringEvent.Set();
+		}
+
 		public void Processor(object data) {
 			string path = (string)data;
 			using (var w = new FileSystemWatcher {
@@ -170,6 +176,10 @@ namespace De.Thekid.INotify
 			        t.Start(path);
 			        _threads.Add(t);
 			    }
+
+			    Thread stop = new Thread(new ParameterizedThreadStart(Stop));
+			    stop.Start("");
+
 			    _stopMonitoringEvent.Wait();
 			    foreach (var thread in _threads)
 			    {


### PR DESCRIPTION
This allows us to use inotify-wait as a child process
and also allows us to shut it down on cmd by sending
Ctrl+Z.