### PR TITLE
Prevent msys(2)/cygwin from mangling paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ else
 endif
 
 inotifywait.exe: src/*.cs
-	$(CSC) /nologo /target:exe /out:$@ src\\*.cs
+	$(CSC) //nologo //target:exe //out:$@ src\\*.cs
 
 clean:
 	-rm inotifywait.exe


### PR DESCRIPTION
Hi,

When compiling under msys2, the parameters get mangled (e.g. `/nologo` gets expanded to a path). Adding a slash prevents msys2 from expanding.

Tested under 
```
 % uname -mo
x86_64 Msys
```

I haven't tested the patch under cygwin though...