### PR TITLE
disable path mangling on MSYS2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ else
 endif
 
 inotifywait.exe: src/*.cs
-	$(CSC) /nologo /target:exe /out:$@ src\\*.cs
+        ifneq (,$(findstring CYGWIN,$(shell uname -s)))
+		$(CSC) '/nologo' '/target:exe' '/out:$@' 'src\\*.cs'
+        else
+		$(CSC) //nologo //target:exe //out:$@ src\\*.cs
+        endif
 
 clean:
 	-rm inotifywait.exe


### PR DESCRIPTION
Compatible with cygwin as well as MSYS2