### PR TITLE
Implement `--include[i]` with regexes

### DIFF
--- a/src/ArgumentParser.cs
+++ b/src/ArgumentParser.cs
@@ -75,6 +75,14 @@ namespace De.Thekid.INotify
             {
                 result.Exclude = new Regex(Value(args, ++i, "exclude"), RegexOptions.IgnoreCase);
             }
+            else if ("--include" == option)
+            {
+                result.Include = new Regex(Value(args, ++i, "include"));
+            }
+            else if ("--includei" == option)
+            {
+                result.Include = new Regex(Value(args, ++i, "include"), RegexOptions.IgnoreCase);
+            }
             else if (option.StartsWith("--event="))
             {
                 result.AddEvents(option.Split(new Char[]{'='}, 2)[1].Split(','));
@@ -90,6 +98,14 @@ namespace De.Thekid.INotify
             else if (option.StartsWith("--excludei="))
             {
                 result.Exclude = new Regex(option.Split(new Char[]{'='}, 2)[1], RegexOptions.IgnoreCase);
+            }
+            else if (option.StartsWith("--include="))
+            {
+                result.Include = new Regex(option.Split(new Char[]{'='}, 2)[1]);
+            }
+            else if (option.StartsWith("--includei="))
+            {
+                result.Include = new Regex(option.Split(new Char[]{'='}, 2)[1], RegexOptions.IgnoreCase);
             }
             else if (Directory.Exists(option) || File.Exists(option))
             {
@@ -140,6 +156,8 @@ namespace De.Thekid.INotify
             writer.WriteLine("--format format: Format string for output.");
             writer.WriteLine("--exclude:       Do not process any events whose filename matches the specified regex");
             writer.WriteLine("--excludei:      Ditto, case-insensitive");
+            writer.WriteLine("--include:       Only process events whose filename matches the specified regex");
+            writer.WriteLine("--includei:      Ditto, case-insensitive");
             writer.WriteLine();
             writer.WriteLine("Formats:");
             writer.WriteLine("%e             : Event name");

--- a/src/Arguments.cs
+++ b/src/Arguments.cs
@@ -27,6 +27,9 @@ namespace De.Thekid.INotify
             set { format = value; }
         }
 
+        /// --include[i]
+        public Regex Include { get; set; }
+
         /// --exclude[i]
         public Regex Exclude { get; set; }
 

--- a/src/Runner.cs
+++ b/src/Runner.cs
@@ -68,11 +68,14 @@ namespace De.Thekid.INotify
                     return;
                 }
         
-                if (null != _args.Exclude && _args.Exclude.IsMatch(e.FullPath))
+                if (
+                    (null != _args.Exclude && _args.Exclude.IsMatch(e.FullPath)) ||
+                    (null != _args.Include && !_args.Include.IsMatch(e.FullPath))
+                )
                 {
                     return;
                 }
-        
+
                 outputAction();
         
                 // If only looking for one change, signal to stop


### PR DESCRIPTION
See #38 and https://unix.stackexchange.com/questions/323901/how-to-use-inotifywait-to-watch-a-directory-for-creation-of-files-of-a-specific

## Usage

```bash
$ ./inotifywait.exe
Usage: inotifywait [options] path [...]

Options:
-r/--recursive:  Recursively watch all files and subdirectories inside path
-m/--monitor:    Keep running until killed (e.g. via Ctrl+C)
-q/--quiet:      Do not output information about actions
-e/--event list: Which events (create, modify, delete, move) to watch, comma-separated. Default: all
--format format: Format string for output.
--exclude:       Do not process any events whose filename matches the specified regex
--excludei:      Ditto, case-insensitive
--include:       Only process events whose filename matches the specified regex
--includei:      Ditto, case-insensitive

Formats:
%e             : Event name
%f             : File name
%w             : Path name
%T             : Current date and time
```

## Example

Shell window 1:
```bash
$ ./inotifywait.exe --recursive --include '\.cs$' .
===> Watching C:\Tools\Cygwin\home\timmf\devel\inotify-win -r*.* for create, modify, delete, move
```

Shell window 2:
```bash
$ touch src/test
# Nothing happens in shell window 1

$ touch src/Runner.cs
# Shell window 1 outputs: C:\Tools\Cygwin\home\timmf\devel\inotify-win\src MODIFY Runner.cs
```
